### PR TITLE
ignition-gazebo2 needed at build time

### DIFF
--- a/ros1_ign_gazebo_demos/package.xml
+++ b/ros1_ign_gazebo_demos/package.xml
@@ -7,7 +7,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <exec_depend>ignition-gazebo2</exec_depend>
+  <depend>ignition-gazebo2</depend>
   <exec_depend>ros1_ign_bridge</exec_depend>
   <exec_depend>ros1_ign_point_cloud</exec_depend>
   <exec_depend>rqt_image_view</exec_depend>


### PR DESCRIPTION
Failing here: https://build.osrfoundation.org/job/ros1-ign-gazebo-demos-bloom-debbuilder/1//consoleFull#console-section-10