### PR TITLE
Image bridge using image_transport

### DIFF
--- a/ros1_ign_bridge/CMakeLists.txt
+++ b/ros1_ign_bridge/CMakeLists.txt
@@ -52,6 +52,30 @@ foreach(bridge ${bridge_executables})
   )
 endforeach(bridge)
 
+set(bridge_lib
+  ros1_ign_bridge_lib
+)
+
+add_library(${bridge_lib}
+  ${common_sources}
+)
+target_link_libraries(${bridge_lib}
+  ${catkin_LIBRARIES}
+  ignition-msgs${IGN_MSGS_VER}::core
+  ignition-transport${IGN_TRANSPORT_VER}::core
+)
+
+catkin_package(INCLUDE_DIRS include
+               LIBRARIES ${bridge_lib})
+
+install(TARGETS ${bridge_lib}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+
+install(DIRECTORY include/${PROJECT_NAME}/
+        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+
 # Tests
 find_package(rostest REQUIRED)
 

--- a/ros1_ign_gazebo_demos/README.md
+++ b/ros1_ign_gazebo_demos/README.md
@@ -55,15 +55,11 @@ Then send a command
 Depth camera data can be obtained as:
 
 * `sensor_msgs/Image`, through `ros1_ign_bridge` or `ros1_ign_image`
-* `sendor_msgs/PointCloud2`, through `ros1_ign_bridge` or `ros1_ign_point_cloud`
+* `sendor_msgs/PointCloud2`, through `ros1_ign_point_cloud`
 
 Using the image bridge (unidirectional, uses [image_transport](http://wiki.ros.org/image_transport)):
 
     roslaunch ros1_ign_gazebo_demos image_bridge.launch
-
-Using the regular bridge:
-
-    roslaunch ros1_ign_gazebo_demos depth_camera_bridge.launch
 
 Using Ignition Gazebo plugin:
 

--- a/ros1_ign_gazebo_demos/README.md
+++ b/ros1_ign_gazebo_demos/README.md
@@ -26,6 +26,14 @@ Publishes fluid pressure readings.
 
 Publishes RGB camera image and info.
 
+Images can be exposed to ROS through `ros1_ign_bridge` or `ros1_ign_image`.
+
+Using the image bridge (unidirectional, uses [image_transport](http://wiki.ros.org/image_transport)):
+
+    roslaunch ros1_ign_gazebo_demos image_bridge.launch
+
+Using the regular bridge:
+
     roslaunch ros1_ign_gazebo_demos camera.launch
 
 ![](images/camera_demo.png)
@@ -44,7 +52,20 @@ Then send a command
 
 ## Depth camera
 
-Publishes depth camera images and point clouds.
+Depth camera data can be obtained as:
+
+* `sensor_msgs/Image`, through `ros1_ign_bridge` or `ros1_ign_image`
+* `sendor_msgs/PointCloud2`, through `ros1_ign_bridge` or `ros1_ign_point_cloud`
+
+Using the image bridge (unidirectional, uses [image_transport](http://wiki.ros.org/image_transport)):
+
+    roslaunch ros1_ign_gazebo_demos image_bridge.launch
+
+Using the regular bridge:
+
+    roslaunch ros1_ign_gazebo_demos depth_camera_bridge.launch
+
+Using Ignition Gazebo plugin:
 
     roslaunch ros1_ign_gazebo_demos depth_camera.launch
 
@@ -87,10 +108,14 @@ Publishes magnetic field readings.
 
 RGBD camera data can be obtained as:
 
-* `sensor_msgs/Image`, through the `ros1_ign_bridge`
-* `sendor_msgs/PointCloud2`, through the `ros1_ign_bridge` or `ros1_ign_point_cloud`
+* `sensor_msgs/Image`, through `ros1_ign_bridge` or `ros1_ign_image`
+* `sendor_msgs/PointCloud2`, through `ros1_ign_bridge` or `ros1_ign_point_cloud`
 
-Using the bridge:
+Using the image bridge (unidirectional, uses [image_transport](http://wiki.ros.org/image_transport)):
+
+    roslaunch ros1_ign_gazebo_demos image_bridge.launch
+
+Using the regular bridge:
 
     roslaunch ros1_ign_gazebo_demos rgbd_camera_bridge.launch
 

--- a/ros1_ign_gazebo_demos/launch/image_bridge.launch
+++ b/ros1_ign_gazebo_demos/launch/image_bridge.launch
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<launch>
+
+  <include file="$(find ros1_ign_gazebo_demos)/launch/ign_gazebo.launch">
+    <arg name="args" value="-r -v 3 sensors_demo.sdf"/>
+  </include>
+
+  <node
+    pkg="ros1_ign_image"
+    type="image_bridge"
+    name="$(anon ros1_ign_image)"
+    output="screen"
+    args="camera depth_camera rgbd_camera/image rgbd_camera/depth_image">
+  </node>
+
+  <node
+    pkg="rqt_image_view"
+    type="rqt_image_view"
+    name="rqt_image_view"
+    args="/camera">
+  </node>
+</launch>

--- a/ros1_ign_gazebo_demos/package.xml
+++ b/ros1_ign_gazebo_demos/package.xml
@@ -8,7 +8,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>ignition-gazebo2</depend>
-  <exec_depend>image-transport-plugins</exec_depend>
+  <exec_depend>compressed-image-transport</exec_depend>
   <exec_depend>ros1_ign_bridge</exec_depend>
   <exec_depend>ros1_ign_image</exec_depend>
   <exec_depend>ros1_ign_point_cloud</exec_depend>

--- a/ros1_ign_gazebo_demos/package.xml
+++ b/ros1_ign_gazebo_demos/package.xml
@@ -8,7 +8,9 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>ignition-gazebo2</depend>
+  <exec_depend>image-transport-plugins</exec_depend>
   <exec_depend>ros1_ign_bridge</exec_depend>
+  <exec_depend>ros1_ign_image</exec_depend>
   <exec_depend>ros1_ign_point_cloud</exec_depend>
   <exec_depend>rqt_image_view</exec_depend>
   <exec_depend>rqt_plot</exec_depend>

--- a/ros1_ign_gazebo_demos/package.xml
+++ b/ros1_ign_gazebo_demos/package.xml
@@ -8,7 +8,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>ignition-gazebo2</depend>
-  <exec_depend>compressed-image-transport</exec_depend>
+  <exec_depend>image_transport_plugins</exec_depend>
   <exec_depend>ros1_ign_bridge</exec_depend>
   <exec_depend>ros1_ign_image</exec_depend>
   <exec_depend>ros1_ign_point_cloud</exec_depend>

--- a/ros1_ign_image/CMakeLists.txt
+++ b/ros1_ign_image/CMakeLists.txt
@@ -56,10 +56,10 @@ set(test_subscribers
 )
 
 foreach(test_publisher ${test_publishers})
-  add_executable(${test_publisher}
+  add_executable(${test_publisher}_image
     test/publishers/${test_publisher}.cpp
   )
-  target_link_libraries(${test_publisher}
+  target_link_libraries(${test_publisher}_image
     ${catkin_LIBRARIES}
     ignition-msgs${IGN_MSGS_VER}::core
     ignition-transport${IGN_TRANSPORT_VER}::core
@@ -69,10 +69,10 @@ foreach(test_publisher ${test_publishers})
 endforeach(test_publisher)
 
 foreach(test_subscriber ${test_subscribers})
-  add_rostest_gtest(test_${test_subscriber}
+  add_rostest_gtest(test_${test_subscriber}_image
     test/${test_subscriber}.test
     test/subscribers/${test_subscriber}.cpp)
-  target_link_libraries(test_${test_subscriber}
+  target_link_libraries(test_${test_subscriber}_image
     ${catkin_LIBRARIES}
     ignition-msgs${IGN_MSGS_VER}::core
     ignition-transport${IGN_TRANSPORT_VER}::core

--- a/ros1_ign_image/CMakeLists.txt
+++ b/ros1_ign_image/CMakeLists.txt
@@ -44,3 +44,38 @@ install(TARGETS ${executable}
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
+# Tests
+find_package(rostest REQUIRED)
+
+set(test_publishers
+  ign_publisher
+)
+
+set(test_subscribers
+  ros1_subscriber
+)
+
+foreach(test_publisher ${test_publishers})
+  add_executable(${test_publisher}
+    test/publishers/${test_publisher}.cpp
+  )
+  target_link_libraries(${test_publisher}
+    ${catkin_LIBRARIES}
+    ignition-msgs${IGN_MSGS_VER}::core
+    ignition-transport${IGN_TRANSPORT_VER}::core
+    gtest
+    gtest_main
+  )
+endforeach(test_publisher)
+
+foreach(test_subscriber ${test_subscribers})
+  add_rostest_gtest(test_${test_subscriber}
+    test/${test_subscriber}.test
+    test/subscribers/${test_subscriber}.cpp)
+  target_link_libraries(test_${test_subscriber}
+    ${catkin_LIBRARIES}
+    ignition-msgs${IGN_MSGS_VER}::core
+    ignition-transport${IGN_TRANSPORT_VER}::core
+  )
+endforeach(test_subscriber)
+

--- a/ros1_ign_image/CMakeLists.txt
+++ b/ros1_ign_image/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(ros1_ign_image)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra)
+endif()
+
+find_package(catkin REQUIRED COMPONENTS
+  image_transport
+  ros1_ign_bridge
+  roscpp
+  sensor_msgs)
+
+find_package(ignition-msgs4 QUIET REQUIRED)
+set(IGN_MSGS_VER ${ignition-msgs4_VERSION_MAJOR})
+
+find_package(ignition-transport7 QUIET REQUIRED)
+set(IGN_TRANSPORT_VER ${ignition-transport7_VERSION_MAJOR})
+
+catkin_package()
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+set(executable
+  image_bridge
+)
+
+add_executable(${executable}
+  src/image_bridge.cpp
+)
+target_link_libraries(${executable}
+  ${catkin_LIBRARIES}
+  ignition-msgs${IGN_MSGS_VER}::core
+  ignition-transport${IGN_TRANSPORT_VER}::core
+)
+install(TARGETS ${executable}
+        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+

--- a/ros1_ign_image/README.md
+++ b/ros1_ign_image/README.md
@@ -1,0 +1,11 @@
+# Image utilities for using ROS 1 and Ignition Transport
+
+This package provides a unidirectional bridge for images from Ignition to ROS.
+The bridge subscribes to Ignition image messages (`ignition::msgs::Image`)
+and republishes them to ROS using [image_transport](http://wiki.ros.org/image_transport).
+
+For compressed images, install
+[compressed_image_transport](http://wiki.ros.org/compressed_image_transport)
+and the bridge will publish `/compressed` images. The same goes for other
+`image_transport` plugins.
+

--- a/ros1_ign_image/package.xml
+++ b/ros1_ign_image/package.xml
@@ -1,0 +1,16 @@
+<package format="2">
+  <name>ros1_ign_image</name>
+  <version>0.5.0</version>
+  <description>Image utilities for Ignition simulation with ROS 1.</description>
+  <license>Apache 2.0</license>
+  <maintainer email="louise@openrobotics.org">Louise Poubel</maintainer>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>ignition-msgs4</depend>
+  <depend>ignition-transport7</depend>
+  <depend>image_transport</depend>
+  <depend>ros1_ign_bridge</depend>
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
+</package>

--- a/ros1_ign_image/src/image_bridge.cpp
+++ b/ros1_ign_image/src/image_bridge.cpp
@@ -1,0 +1,98 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <string>
+
+#include <ignition/transport/Node.hh>
+
+#include <image_transport/image_transport.h>
+#include <ros/ros.h>
+#include <ros1_ign_bridge/convert_builtin_interfaces.hpp>
+
+//////////////////////////////////////////////////
+/// \brief Bridges one topic
+class Handler
+{
+  /// \brief Constructor
+  /// \param[in] _topic Image base topic
+  /// \param[in] _it_node Pointer to image transport node
+  /// \param[in] _ign_node Pointer to Ignition node
+  public: Handler(
+      const std::string & _topic,
+      std::shared_ptr<image_transport::ImageTransport> _it_node,
+      std::shared_ptr<ignition::transport::Node> _ign_node)
+  {
+    this->ros_pub = _it_node->advertise(_topic, 1);
+
+    _ign_node->Subscribe(_topic, &Handler::OnImage, this);
+  }
+
+  /// \brief Callback when Ignition image is received
+  /// \param[in] _ign_msg Ignition message
+  private: void OnImage(const ignition::msgs::Image & _ign_msg)
+  {
+    sensor_msgs::Image ros_msg;
+    ros1_ign_bridge::convert_ign_to_1(_ign_msg, ros_msg);
+    this->ros_pub.publish(ros_msg);
+  }
+
+  /// \brief ROS image publisher
+  private: image_transport::Publisher ros_pub;
+};
+
+//////////////////////////////////////////////////
+void usage()
+{
+  std::cerr << "Bridge a collection of Ignition Transport image topics to ROS "
+            << "using image_transport.\n\n"
+            << "  image_bridge <topic> <topic> ..\n\n"
+            << "E.g.: image_bridge /camera/front/image_raw" << std::endl;
+}
+
+//////////////////////////////////////////////////
+int main(int argc, char * argv[])
+{
+  if (argc < 2)
+  {
+    usage();
+    return -1;
+  }
+
+  ros::init(argc, argv, "ros_ign_image");
+
+  // ROS 1 node
+  ros::NodeHandle ros_node;
+  auto it_node = std::make_shared<image_transport::ImageTransport>(ros_node);
+
+  // Ignition node
+  auto ign_node = std::make_shared<ignition::transport::Node>();
+
+  std::vector<std::shared_ptr<Handler>> handlers;
+
+  // Create publishers and subscribers
+  for (auto i = 1; i < argc; ++i)
+  {
+    auto topic = std::string(argv[i]);
+    handlers.push_back(std::make_shared<Handler>(topic, it_node, ign_node));
+  }
+
+  // Spin ROS and Ign until shutdown
+  ros::AsyncSpinner async_spinner(1);
+  async_spinner.start();
+
+  ignition::transport::waitForShutdown();
+
+  return 0;
+}

--- a/ros1_ign_image/test/launch/test_ros1_subscriber.launch
+++ b/ros1_ign_image/test/launch/test_ros1_subscriber.launch
@@ -7,6 +7,6 @@
   />
 
   <!-- Launch the Ignition Transport publisher -->
-  <node name="ign_publisher" pkg="ros1_ign_image" type="ign_publisher" />
+  <node name="ign_publisher" pkg="ros1_ign_image" type="ign_publisher_image" />
 
 </launch>

--- a/ros1_ign_image/test/launch/test_ros1_subscriber.launch
+++ b/ros1_ign_image/test/launch/test_ros1_subscriber.launch
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- Launch the bridge -->
+  <node name="image_bridge_ros1_subscriber" pkg="ros1_ign_image"
+        type="image_bridge"
+        args="/image"
+  />
+
+  <!-- Launch the Ignition Transport publisher -->
+  <node name="ign_publisher" pkg="ros1_ign_image" type="ign_publisher" />
+
+</launch>

--- a/ros1_ign_image/test/publishers/ign_publisher.cpp
+++ b/ros1_ign_image/test/publishers/ign_publisher.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <iostream>
+#include <thread>
+#include <ignition/msgs.hh>
+#include <ignition/transport.hh>
+#include "../test_utils.h"
+
+/// \brief Flag used to break the publisher loop and terminate the program.
+static std::atomic<bool> g_terminatePub(false);
+
+//////////////////////////////////////////////////
+/// \brief Function callback executed when a SIGINT or SIGTERM signals are
+/// captured. This is used to break the infinite loop that publishes messages
+/// and exit the program smoothly.
+void signal_handler(int _signal)
+{
+  if (_signal == SIGINT || _signal == SIGTERM)
+    g_terminatePub = true;
+}
+
+//////////////////////////////////////////////////
+int main(int /*argc*/, char **/*argv*/)
+{
+  // Install a signal handler for SIGINT and SIGTERM.
+  std::signal(SIGINT,  signal_handler);
+  std::signal(SIGTERM, signal_handler);
+
+  // Create a transport node and advertise a topic.
+  ignition::transport::Node node;
+
+  // ignition::msgs::Image.
+  auto image_pub = node.Advertise<ignition::msgs::Image>("image");
+  ignition::msgs::Image image_msg;
+  ros1_ign_image::testing::createTestMsg(image_msg);
+
+  // Publish messages at 1Hz.
+  while (!g_terminatePub)
+  {
+    image_pub.Publish(image_msg);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  return 0;
+}

--- a/ros1_ign_image/test/ros1_subscriber.test
+++ b/ros1_ign_image/test/ros1_subscriber.test
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<launch>
+
+  <include file="$(find ros1_ign_image)/test/launch/test_ros1_subscriber.launch">
+  </include>
+
+  <test test-name="ign_ros1" pkg="ros1_ign_image" type="test_ros1_subscriber" time-limit="60.0" />
+
+</launch>

--- a/ros1_ign_image/test/ros1_subscriber.test
+++ b/ros1_ign_image/test/ros1_subscriber.test
@@ -4,6 +4,6 @@
   <include file="$(find ros1_ign_image)/test/launch/test_ros1_subscriber.launch">
   </include>
 
-  <test test-name="ign_ros1" pkg="ros1_ign_image" type="test_ros1_subscriber" time-limit="60.0" />
+  <test test-name="ign_ros1" pkg="ros1_ign_image" type="test_ros1_subscriber_image" time-limit="60.0" />
 
 </launch>

--- a/ros1_ign_image/test/subscribers/ros1_subscriber.cpp
+++ b/ros1_ign_image/test/subscribers/ros1_subscriber.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+#include <sensor_msgs/Image.h>
+#include <chrono>
+#include "../test_utils.h"
+
+//////////////////////////////////////////////////
+/// \brief A class for testing ROS 1 topic subscription.
+template <typename ROS_T>
+class MyTestClass
+{
+  /// \brief Class constructor.
+  public: MyTestClass(const std::string &_topic)
+  {
+    this->sub = this->n.subscribe(_topic, 1000, &MyTestClass::Cb, this);
+  }
+
+  /// \brief Member function called each time a topic update is received.
+  public: void Cb(const ROS_T& _msg)
+  {
+    ros1_ign_image::testing::compareTestMsg(_msg);
+    this->callbackExecuted = true;
+  };
+
+  /// \brief Member variables that flag when the actions are executed.
+  public: bool callbackExecuted = false;
+
+  /// \brief ROS node handle;
+  private: ros::NodeHandle n;
+
+  /// \brief ROS subscriber;
+  private: ros::Subscriber sub;
+};
+
+/////////////////////////////////////////////////
+TEST(ROS1SubscriberTest, Image)
+{
+  MyTestClass<sensor_msgs::Image> client("image");
+
+  using namespace std::chrono_literals;
+  ros1_ign_image::testing::waitUntilBoolVarAndSpin(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "ros1_image_subscriber");
+
+  return RUN_ALL_TESTS();
+}

--- a/ros1_ign_image/test/test_utils.h
+++ b/ros1_ign_image/test/test_utils.h
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2018 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef ROS1_IGN_IMAGE__TEST_UTILS_H_
+#define ROS1_IGN_IMAGE__TEST_UTILS_H_
+
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+#include <std_msgs/Header.h>
+#include <sensor_msgs/Image.h>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <ignition/msgs.hh>
+
+namespace ros1_ign_image
+{
+namespace testing
+{
+  /// \brief Wait until a boolean variable is set to true for a given number
+  /// of times.
+  /// \param[in out] _boolVar The bool variable.
+  /// \param[in] _sleepEach Time duration to wait between each retry.
+  /// \param[in] _retries The number of retries.
+  ///
+  /// E.g.:
+  ///   using namespace std::chrono_literals;
+  ///   waitUntilBoolVar(myVar, 1ms, 10);
+  template <class Rep, class Period>
+  void waitUntilBoolVar(
+      bool &_boolVar,
+      const std::chrono::duration<Rep, Period> &_sleepEach,
+      const int _retries)
+  {
+    int i = 0;
+    while (!_boolVar && i < _retries)
+    {
+      ++i;
+      std::this_thread::sleep_for(_sleepEach);
+    }
+  }
+
+  /// \brief Wait until a boolean variable is set to true for a given number
+  /// of times. This function calls ros::spinOnce each iteration.
+  /// \param[in out] _boolVar The bool variable.
+  /// \param[in] _sleepEach Time duration to wait between each retry.
+  /// \param[in] _retries The number of retries.
+  ///
+  /// E.g.:
+  ///   using namespace std::chrono_literals;
+  ///   waitUntilBoolVar(myVar, 1ms, 10);
+  template <class Rep, class Period>
+  void waitUntilBoolVarAndSpin(
+      bool &_boolVar,
+      const std::chrono::duration<Rep, Period> &_sleepEach,
+      const int _retries)
+  {
+    int i = 0;
+    while (!_boolVar && i < _retries)
+    {
+      ++i;
+      std::this_thread::sleep_for(_sleepEach);
+      ros::spinOnce();
+    }
+  }
+
+  //////////////////////////////////////////////////
+  /// ROS 1 test utils
+  //////////////////////////////////////////////////
+
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
+  void createTestMsg(std_msgs::Header &_msg)
+  {
+    _msg.seq        = 1;
+    _msg.stamp.sec  = 2;
+    _msg.stamp.nsec = 3;
+    _msg.frame_id   = "frame_id_value";
+  }
+
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const std_msgs::Header &_msg)
+  {
+    std_msgs::Header expected_msg;
+    createTestMsg(expected_msg);
+
+    EXPECT_GE(expected_msg.seq,        0u);
+    EXPECT_EQ(expected_msg.stamp.sec,  _msg.stamp.sec);
+    EXPECT_EQ(expected_msg.stamp.nsec, _msg.stamp.nsec);
+    EXPECT_EQ(expected_msg.frame_id,   _msg.frame_id);
+  }
+
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
+  void createTestMsg(sensor_msgs::Image &_msg)
+  {
+    std_msgs::Header header_msg;
+    createTestMsg(header_msg);
+
+    _msg.header       = header_msg;
+    _msg.width        = 320;
+    _msg.height       = 240;
+    _msg.encoding     = "rgb8";
+    _msg.is_bigendian = false;
+    _msg.step         = _msg.width * 3;
+    _msg.data.resize(_msg.height * _msg.step, '1');
+  }
+
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const sensor_msgs::Image &_msg)
+  {
+    sensor_msgs::Image expected_msg;
+    createTestMsg(expected_msg);
+
+    compareTestMsg(_msg.header);
+    EXPECT_EQ(expected_msg.width,        _msg.width);
+    EXPECT_EQ(expected_msg.height,       _msg.height);
+    EXPECT_EQ(expected_msg.encoding,     _msg.encoding);
+    EXPECT_EQ(expected_msg.is_bigendian, _msg.is_bigendian);
+    EXPECT_EQ(expected_msg.step,         _msg.step);
+  }
+
+  //////////////////////////////////////////////////
+  /// Ignition::msgs test utils
+  //////////////////////////////////////////////////
+
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
+  void createTestMsg(ignition::msgs::Header &_msg)
+  {
+    auto seq_entry = _msg.add_data();
+    seq_entry->set_key("seq");
+    seq_entry->add_value("1");
+    _msg.mutable_stamp()->set_sec(2);
+    _msg.mutable_stamp()->set_nsec(3);
+    auto frame_id_entry = _msg.add_data();
+    frame_id_entry->set_key("frame_id");
+    frame_id_entry->add_value("frame_id_value");
+  }
+
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const ignition::msgs::Header &_msg)
+  {
+    ignition::msgs::Header expected_msg;
+    createTestMsg(expected_msg);
+
+    EXPECT_EQ(expected_msg.stamp().sec(),    _msg.stamp().sec());
+    EXPECT_EQ(expected_msg.stamp().nsec(),   _msg.stamp().nsec());
+    EXPECT_GE(_msg.data_size(),              2);
+    EXPECT_EQ(expected_msg.data(0).key(),    _msg.data(0).key());
+    EXPECT_EQ(1,                             _msg.data(0).value_size());
+    std::string value = _msg.data(0).value(0);
+    try
+    {
+      uint32_t ul = std::stoul(value, nullptr);
+      EXPECT_GE(ul, 0u);
+    }
+    catch (std::exception & e)
+    {
+      FAIL();
+    }
+    EXPECT_EQ(expected_msg.data(1).key(),    _msg.data(1).key());
+    EXPECT_EQ(1,                             _msg.data(1).value_size());
+    EXPECT_EQ(expected_msg.data(1).value(0), _msg.data(1).value(0));
+  }
+
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
+  void createTestMsg(ignition::msgs::Image &_msg)
+  {
+    ignition::msgs::Header header_msg;
+    createTestMsg(header_msg);
+
+    _msg.mutable_header()->CopyFrom(header_msg);
+    _msg.set_width(320);
+    _msg.set_height(240);
+    _msg.set_pixel_format_type(ignition::msgs::PixelFormatType::RGB_INT8);
+    _msg.set_step(_msg.width() * 3);
+    _msg.set_data(std::string(_msg.height() * _msg.step(), '1'));
+  }
+
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const ignition::msgs::Image &_msg)
+  {
+    ignition::msgs::Image expected_msg;
+    createTestMsg(expected_msg);
+
+    compareTestMsg(_msg.header());
+    EXPECT_EQ(expected_msg.width(),             _msg.width());
+    EXPECT_EQ(expected_msg.height(),            _msg.height());
+    EXPECT_EQ(expected_msg.pixel_format_type(), _msg.pixel_format_type());
+    EXPECT_EQ(expected_msg.step(),              _msg.step());
+    EXPECT_EQ(expected_msg.data(),              _msg.data());
+  }
+}
+}
+
+#endif  // ROS1_IGN_BRIDGE__TEST_UTILS_H_


### PR DESCRIPTION
We've been bridging images directly with `ros1_ign_bridge`, but for some use cases, it's interesting to bring the power of [image_transport](http://wiki.ros.org/image_transport) and its plugins for features like compression.

This PR adds a new package, `ros1_ign_image`, which is documented on its README.

Also check out the new demo on `ros1_ign_gazebo_demos` that exercises the new package.