### PR TITLE
Missing rostest dependency in image package

### DIFF
--- a/ros1_ign_image/package.xml
+++ b/ros1_ign_image/package.xml
@@ -13,4 +13,6 @@
   <depend>ros1_ign_bridge</depend>
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
+
+  <test_depend>rostest</test_depend>
 </package>


### PR DESCRIPTION
Failing here: https://build.osrfoundation.org/job/ros1-ign-image-bloom-debbuilder/1/console#console-section-10