### PR TITLE
Support unidirectional bridge topics

### DIFF
--- a/ros1_ign_bridge/src/parameter_bridge.cpp
+++ b/ros1_ign_bridge/src/parameter_bridge.cpp
@@ -49,14 +49,14 @@ void usage()
 {
   ROS_ERROR_STREAM(
       "Bridge a collection of ROS1 and Ignition Transport topics.\n\n"
-      << "  parameter_bridge <topic@ROS1_type[@,<,>]Ign_type> .. "
+      << "  parameter_bridge <topic@ROS1_type(@,[,])Ign_type> .. "
       << " <topic@ROS1_type@Ign_type>\n\n"
       << "The first @ symbol delimits the topic name from the message types.\n"
       << "Following the first @ symbol is the ROS1 message type.\n"
-      << "The ROS1 message type is followed by an @, <, or > symbol where\n"
+      << "The ROS1 message type is followed by an @, [, or ] symbol where\n"
       << "    @  ==  a bidirectional bridge, \n"
-      << "    <  == a bridge from Ignition to ROS1,\n"
-      << "    >  == a bridge from ROS1 to Ignition.\n"
+      << "    [  == a bridge from Ignition to ROS1,\n"
+      << "    ]  == a bridge from ROS1 to Ignition.\n"
       << "Following the direction symbol is the Ignition Transport message "
       << "type.\n"
       << "A bidirectional bridge example:\n"
@@ -101,16 +101,16 @@ int main(int argc, char * argv[])
 
     // Get the direction delimeter, which should be one of:
     //   @ == bidirectional, or
-    //   < == only from IGN to ROS, or
-    //   > == only from ROS to IGN.
+    //   [ == only from IGN to ROS, or
+    //   ] == only from ROS to IGN.
     delimPos = arg.find("@");
     Direction direction = BIDIRECTIONAL;
     if (delimPos == std::string::npos || delimPos == 0)
     {
-      delimPos = arg.find("<");
+      delimPos = arg.find("[");
       if (delimPos == std::string::npos || delimPos == 0)
       {
-        delimPos = arg.find(">");
+        delimPos = arg.find("]");
         if (delimPos == std::string::npos || delimPos == 0)
         {
           usage();

--- a/ros1_ign_bridge/src/parameter_bridge.cpp
+++ b/ros1_ign_bridge/src/parameter_bridge.cpp
@@ -50,17 +50,23 @@ void usage()
   ROS_ERROR_STREAM(
       "Bridge a collection of ROS1 and Ignition Transport topics.\n\n"
       << "  parameter_bridge <topic@ROS1_type(@,[,])Ign_type> .. "
-      << " <topic@ROS1_type@Ign_type>\n\n"
+      << " <topic@ROS1_type(@,[,])Ign_type>\n\n"
       << "The first @ symbol delimits the topic name from the message types.\n"
       << "Following the first @ symbol is the ROS1 message type.\n"
       << "The ROS1 message type is followed by an @, [, or ] symbol where\n"
-      << "    @  ==  a bidirectional bridge, \n"
+      << "    @  == a bidirectional bridge, \n"
       << "    [  == a bridge from Ignition to ROS1,\n"
       << "    ]  == a bridge from ROS1 to Ignition.\n"
       << "Following the direction symbol is the Ignition Transport message "
-      << "type.\n"
+      << "type.\n\n"
       << "A bidirectional bridge example:\n"
       << "    parameter_bridge /chatter@std_msgs/String@ignition.msgs"
+      << ".StringMsg\n\n"
+      << "A bridge from Ignition to ROS1 example:\n"
+      << "    parameter_bridge /chatter@std_msgs/String[ignition.msgs"
+      << ".StringMsg\n\n"
+      << "A bridge from ROS1 to Ignition example:\n"
+      << "    parameter_bridge /chatter@std_msgs/String]ignition.msgs"
       << ".StringMsg" << std::endl);
 }
 

--- a/ros1_ign_bridge/src/parameter_bridge.cpp
+++ b/ros1_ign_bridge/src/parameter_bridge.cpp
@@ -33,14 +33,34 @@
 
 #include "ros1_ign_bridge/bridge.hpp"
 
+// Direction of bridge.
+enum Direction
+{
+  // Both directions.
+  BIDIRECTIONAL = 0,
+  // Only from IGN to ROS
+  FROM_IGN_TO_ROS = 1,
+  // Only from ROS to IGN
+  FROM_ROS_TO_IGN = 2,
+};
+
 //////////////////////////////////////////////////
 void usage()
 {
   ROS_ERROR_STREAM(
       "Bridge a collection of ROS1 and Ignition Transport topics.\n\n"
-      << "  parameter_bridge <topic@ROS1_type@Ign_type> .. "
+      << "  parameter_bridge <topic@ROS1_type[@,<,>]Ign_type> .. "
       << " <topic@ROS1_type@Ign_type>\n\n"
-      << "E.g.: parameter_bridge /chatter@std_msgs/String@ignition.msgs"
+      << "The first @ symbol delimits the topic name from the message types.\n"
+      << "Following the first @ symbol is the ROS1 message type.\n"
+      << "The ROS1 message type is followed by an @, <, or > symbol where\n"
+      << "    @  ==  a bidirectional bridge, \n"
+      << "    <  == a bridge from Ignition to ROS1,\n"
+      << "    >  == a bridge from ROS1 to Ignition.\n"
+      << "Following the direction symbol is the Ignition Transport message "
+      << "type.\n"
+      << "A bidirectional bridge example:\n"
+      << "    parameter_bridge /chatter@std_msgs/String@ignition.msgs"
       << ".StringMsg" << std::endl);
 }
 
@@ -60,7 +80,9 @@ int main(int argc, char * argv[])
   // Ignition node
   auto ign_node = std::make_shared<ignition::transport::Node>();
 
-  std::list<ros1_ign_bridge::BridgeHandles> all_handles;
+  std::list<ros1_ign_bridge::BridgeHandles> bidirectional_handles;
+  std::list<ros1_ign_bridge::BridgeIgnto1Handles> ign_to_ros1_handles;
+  std::list<ros1_ign_bridge::Bridge1toIgnHandles> ros1_to_ign_handles;
 
   // Parse all arguments.
   const std::string delim = "@";
@@ -77,11 +99,32 @@ int main(int argc, char * argv[])
     std::string topic_name = arg.substr(0, delimPos);
     arg.erase(0, delimPos + delim.size());
 
-    delimPos = arg.find(delim);
+    // Get the direction delimeter, which should be one of:
+    //   @ == bidirectional, or
+    //   < == only from IGN to ROS, or
+    //   > == only from ROS to IGN.
+    delimPos = arg.find("@");
+    Direction direction = BIDIRECTIONAL;
     if (delimPos == std::string::npos || delimPos == 0)
     {
-      usage();
-      return -1;
+      delimPos = arg.find("<");
+      if (delimPos == std::string::npos || delimPos == 0)
+      {
+        delimPos = arg.find(">");
+        if (delimPos == std::string::npos || delimPos == 0)
+        {
+          usage();
+          return -1;
+        }
+        else
+        {
+          direction = FROM_ROS_TO_IGN;
+        }
+      }
+      else
+      {
+        direction = FROM_IGN_TO_ROS;
+      }
     }
     std::string ros1_type_name = arg.substr(0, delimPos);
     arg.erase(0, delimPos + delim.size());
@@ -96,13 +139,31 @@ int main(int argc, char * argv[])
 
     try
     {
-      ros1_ign_bridge::BridgeHandles handles =
-        ros1_ign_bridge::create_bidirectional_bridge(
-          ros1_node, ign_node,
-          ros1_type_name, ign_type_name,
-          topic_name, queue_size);
-
-      all_handles.push_back(handles);
+      switch (direction)
+      {
+        default:
+        case BIDIRECTIONAL:
+          bidirectional_handles.push_back(
+              ros1_ign_bridge::create_bidirectional_bridge(
+                ros1_node, ign_node,
+                ros1_type_name, ign_type_name,
+                topic_name, queue_size));
+          break;
+        case FROM_IGN_TO_ROS:
+          ign_to_ros1_handles.push_back(
+              ros1_ign_bridge::create_bridge_from_ign_to_ros(
+                ign_node, ros1_node,
+                ign_type_name, topic_name, queue_size,
+                ros1_type_name, topic_name, queue_size));
+          break;
+        case FROM_ROS_TO_IGN:
+          ros1_to_ign_handles.push_back(
+              ros1_ign_bridge::create_bridge_from_ros_to_ign(
+                ros1_node, ign_node,
+                ros1_type_name, topic_name, queue_size,
+                ign_type_name, topic_name, queue_size));
+          break;
+      }
     }
     catch (std::runtime_error &_e)
     {


### PR DESCRIPTION
Allow the use of @, [, or ] between the message types to indicate if a bridge should be bidirectional, to ROS, or to IGN.